### PR TITLE
Fiber support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "./node_modules/.bin/babel --copy-files -s -d lib src",
     "copy": "./node_modules/.bin/ncp src lib && ./node_modules/.bin/renamer --regex --find '$' --replace '.flow' 'lib/**/*.js'",
     "prepublish": "npm run clean && npm run copy && npm run build",
-    "test": "npm run lint",
+    "test": "npm run lint && npm run flow",
     "flow": "./node_modules/.bin/flow .",
     "lint": "./node_modules/.bin/eslint ."
   },

--- a/package.json
+++ b/package.json
@@ -35,13 +35,11 @@
     "flow-bin": "^0.53.1",
     "ncp": "^2.0.0",
     "react": "^15.6.1",
-    "react-dom": "^15.6.1",
     "renamer": "^0.6.1",
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
-    "react": ">=0.14",
-    "react-dom": ">=0.14"
+    "react": ">=0.14"
   },
   "devEngines": {
     "node": "8",

--- a/src/ResizeObserver.js
+++ b/src/ResizeObserver.js
@@ -5,7 +5,6 @@
 // Import modules.
 // =============================================================================
 import React from 'react';
-import {findDOMNode} from 'react-dom';
 
 const style = {
   position: 'absolute',
@@ -131,17 +130,12 @@ class ResizeObserver extends React.Component<Props> {
     super(props, context);
     (this: any)._handleScroll = this._handleScroll.bind(this);
     (this: any)._reflow = this._reflow.bind(this);
+    (this: any)._handleRef = this._handleRef.bind(this);
     (this: any)._handleExpandRef = this._handleExpandRef.bind(this);
     (this: any)._handleShrinkRef = this._handleShrinkRef.bind(this);
   }
 
   componentDidMount() {
-    const node = findDOMNode(this);
-
-    if (node instanceof HTMLElement) {
-      this._node = node;
-    }
-
     this._reflow();
 
     this._removeScroll = ResizeObserver.addScrollListener(this._handleScroll);
@@ -251,6 +245,10 @@ class ResizeObserver extends React.Component<Props> {
     }
   }
 
+  _handleRef(node: HTMLElement | null) {
+    this._node = node;
+  }
+
   _handleExpandRef(node: HTMLElement | null) {
     this._reset(node);
     this._expandRef = node;
@@ -264,7 +262,7 @@ class ResizeObserver extends React.Component<Props> {
   render() {
     if (this.props.onResize || this.props.onReflow) {
       return (
-        <div style={style}>
+        <div style={style} ref={this._handleRef}>
           <div ref={this._handleExpandRef} style={style}>
             <div style={{...styleChild, width: 100000, height: 100000}}/>
           </div>


### PR DESCRIPTION
`findDOMNode` behaves differently in React 16 due to the switch to fiber under the hood and returns `null` when it shouldn't.

I can't find a proper reference to what has changed. The official documentation hasn't been updated to reflect any breaking changes. It's best to simply avoid using `findDOMNode` in this scenario.