### PR TITLE
Fix bug preventing onPosition callback from firing

### DIFF
--- a/src/ResizeObserver.js
+++ b/src/ResizeObserver.js
@@ -273,7 +273,7 @@ class ResizeObserver extends React.Component<Props> {
       );
     }
 
-    return <noscript/>;
+    return <noscript ref={this._handleRef}/>;
   }
 }
 


### PR DESCRIPTION
The switch from `findDOMNode` to `ref` callbacks introduced a bug preventing the target node rect from being detected when only the `onPosition` callback was supplied.